### PR TITLE
Uart driver cleanup

### DIFF
--- a/src/node_1/Makefile
+++ b/src/node_1/Makefile
@@ -1,0 +1,53 @@
+# List all source files to be compiled; separate with space
+SOURCE_FILES := main.c lib/*
+
+# Set this flag to "yes" (no quotes) to use JTAG; otherwise ISP (SPI) is used
+PROGRAM_WITH_JTAG := yes
+
+# Feel free to ignore anything below this line
+PROGRAMMER := atmelice_isp
+ifeq ($(PROGRAM_WITH_JTAG), yes)
+	PROGRAMMER := atmelice
+endif
+
+BUILD_DIR := build
+TARGET_CPU := atmega162
+TARGET_DEVICE := m162
+
+CC := avr-gcc
+CFLAGS := -O -std=c11 -mmcu=$(TARGET_CPU) -ggdb
+
+OBJECT_FILES = $(SOURCE_FILES:%.c=$(BUILD_DIR)/%.o)
+
+.DEFAULT_GOAL := $(BUILD_DIR)/main.hex
+
+$(BUILD_DIR):
+	mkdir $(BUILD_DIR)
+
+$(BUILD_DIR)/%.o: %.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/main.hex: $(OBJECT_FILES) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(OBJECT_FILES) -o $(BUILD_DIR)/a.out
+	avr-objcopy -j .text -j .data -O ihex $(BUILD_DIR)/a.out $(BUILD_DIR)/main.hex
+
+.PHONY: flash
+flash: $(BUILD_DIR)/main.hex
+	avrdude -p $(TARGET_DEVICE) -c $(PROGRAMMER) -U flash:w:$(BUILD_DIR)/main.hex:i
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: erase
+erase:
+	avrdude -p $(TARGET_DEVICE) -c $(PROGRAMMER) -e
+	
+.PHONY: debug
+debug:
+	if pgrep avarice; then pkill avarice; fi
+	avrdude -p $(TARGET_DEVICE) -c $(PROGRAMMER) -U flash:w:$(BUILD_DIR)/main.hex:i
+	x-terminal-emulator -e avarice --edbg --ignore-intr :4242
+	sleep 2
+	avr-gdb -tui -iex "target remote localhost:4242" $(BUILD_DIR)/a.out
+	killall -s 9 avarice	

--- a/src/node_1/lib/uart_com.c
+++ b/src/node_1/lib/uart_com.c
@@ -1,30 +1,45 @@
+//NOTE: Code is heavily inspired by code found in the Atmega162 datasheet.
+#include <avr/io.h>
+#include <avr/common.h>
 #include "uart_com.h"
 
-void UART_INIT(unsigned int ubrr){
-	UBRR0H = (unsigned char)(ubrr >> 8);
-	
-	UBRR0L = (unsigned char)ubrr;
-	
-	UCSR0B = (1 << RXEN0) | (1 << TXEN0);
-	
-	UCSR0C = (1 << URSEL0) | (1 << USBS0) | (3 << UCSZ00);
-	
-	fdevopen(UART_TRANSMIT,UART_READ);
+//Initialises UART communication.
+//Takes in a given UBRR value. (UART Baud Rate Register)
+void uart_init(unsigned int ubbr)
+{
+		//Set baud rate:
+		UBRR0H = (unsigned char) (ubbr >> 8);
+		UBRR0L = (unsigned char) ubbr;
+
+		//Enable receiver and transmitter:
+		UCSR0B = (1 << RXEN0) | (1 << TXEN0);
+
+		//Set frame format: 8data, 2stop bit:
+		UCSR0C = (1<<URSEL0) | (1<<USBS0) | (3<<UCSZ00);
+		fdevopen(uart_transmit,uart_read);
 }
 
-void UART_TRANSMIT(unsigned char c){
-	while (!(UCSR0A & (1<<UDRE0))){
-		;
-	}
-	/* Put data into buffer, sends the data */
-	UDR0 = c;
+//Transmits one character over UART
+//Takes in the character to transmit
+void uart_transmit(unsigned char data)
+{
+		// Wait for empty transmit buffer
+		while ( !( UCSR0A & (1<<UDRE0)) )
+		{
+				; //Do nothing
+		}
+		// Put data into buffer, sends the data
+		UDR0 = data;
 }
 
-uint8_t UART_READ(void){
-	/* Wait for data to be received */
-	while ( !(UCSR0A & (1<<RXC0)) ){
-		;
-	}
-	/* Get and return received data from buffer */
-	return UDR0;
+//Recieves one character from UART
+unsigned char uart_read(void)
+{
+		// Wait for data to be received
+		while ( !(UCSR0A & (1<<RXC0)) )
+		{
+				; //Do nothing
+		}
+		// Get and return received data from buffer
+		return UDR0;
 }

--- a/src/node_1/lib/uart_com.h
+++ b/src/node_1/lib/uart_com.h
@@ -1,10 +1,15 @@
-#pragma			once
-#include		<avr/io.h>
+//Procedures and functions used to initialise UART, transmit, and receive over UART.
+#ifndef UART_DRIVER_H
+#define UART_DRIVER_H
 
-#define			FOSC	4915200
-#define			BAUD	9600
-#define			MYUBRR	FOSC/16/BAUD-1
+//Initialises UART communication.
+//Takes in a given UBRR value. (UART Baud Rate Register)
+void uart_init(unsigned int ubbr);
 
-uint8_t			UART_READ(void);
-void			UART_TRANSMIT(unsigned char);
-void			UART_INIT(unsigned int);
+//Transmits one character over UART
+//Takes in the character to transmit
+void uart_transmit(unsigned char data);
+
+//Recieves one character from UART
+unsigned char uart_read(void);
+#endif

--- a/src/node_1/lib/uart_com.h
+++ b/src/node_1/lib/uart_com.h
@@ -1,6 +1,6 @@
 //Procedures and functions used to initialise UART, transmit, and receive over UART.
-#ifndef UART_DRIVER_H
-#define UART_DRIVER_H
+#ifndef UART_COM_H
+#define UART_COM_H
 
 //Initialises UART communication.
 //Takes in a given UBRR value. (UART Baud Rate Register)

--- a/src/node_1/main.c
+++ b/src/node_1/main.c
@@ -1,5 +1,6 @@
 #include <avr/io.h>
 #include "lib/uart_com.h"
+#include <stdio.h>
 
 #define F_CPU 4915200 //Clock Speed
 #include <util/delay.h>
@@ -10,12 +11,15 @@
 void main()
 {
 		uart_init(MYUBRR);
-		unsigned char letter = 0x41;
-		_delay_ms(10);
+		unsigned char letter;
+
+		char message[] = "Hei!!!";
+		printf("%s",message);
+
 		while (1)
 		{
-				letter = uart_read();
-				uart_transmit(letter);
-				_delay_ms(100);
+				scanf("%c",&letter);
+				printf("%c",letter);
+				_delay_ms(10);
 		}
 }

--- a/src/node_1/main.c
+++ b/src/node_1/main.c
@@ -11,10 +11,11 @@ void main()
 {
 		uart_init(MYUBRR);
 		unsigned char letter = 0x41;
+		_delay_ms(10);
 		while (1)
 		{
 				letter = uart_read();
 				uart_transmit(letter);
-				_delay_ms(10);
+				_delay_ms(100);
 		}
 }

--- a/src/node_1/main.c
+++ b/src/node_1/main.c
@@ -1,0 +1,20 @@
+#include <avr/io.h>
+#include "lib/uart_com.h"
+
+#define F_CPU 4915200 //Clock Speed
+#include <util/delay.h>
+
+#define BAUD 9600
+#define MYUBRR F_CPU/16/BAUD-1
+
+void main()
+{
+		uart_init(MYUBRR);
+		unsigned char letter = 0x41;
+		while (1)
+		{
+				letter = uart_read();
+				uart_transmit(letter);
+				_delay_ms(10);
+		}
+}


### PR DESCRIPTION
# Changes to the uart driver library to be compliant with the Barr C embedded coding standard. (+ some other changes)

- Added some comments/documentation
- Changed from `#pragma once` import guard to `#ifndef` import guard, see [1.3.4 of the gcc docs](https://gcc.gnu.org/onlinedocs/gcc-2.95.3/cpp_1.html#SEC8).
- Moved imports in library to source file, instead of header file. As is generally recommended
- Changed return type of uart_read to unsigned char (this is subject to discussion)
- Moved "constant `#define`s" to main file. After discussion, they should be either in main file or a specific header file.
- Added the given Makefile, with lib/* as a target (for all our future libraries)
- To import our own libraries, I use `#import "lib/<some library>"`. I prefer this style when we import our own libraries. This is also subject to discussion.

**Important note:** The code on this branch has been tested, and works as expected.
